### PR TITLE
Increase timeout for lambda

### DIFF
--- a/HousingRepairsOnlineApi/serverless.yml
+++ b/HousingRepairsOnlineApi/serverless.yml
@@ -49,6 +49,7 @@ functions:
     name: ${self:service}-${self:provider.stage}
     handler: HousingRepairsOnlineApi::HousingRepairsOnlineApi.LambdaEntryPoint::FunctionHandlerAsync
     role: lambdaExecutionRole
+    timeout: 30
     environment:
       AUTHENTICATION_IDENTIFIER: ${ssm:/HousingRepairsOnlineApi/${self:provider.stage}/authentication-identifier}
       JWT_SECRET: ${ssm:/HousingRepairsOnlineApi/${self:provider.stage}/jwt-secret}


### PR DESCRIPTION
This is because there are 3 apis which are called to retrieve addresses which exceeds the default lambda timeout of 6 seconds 
Co-authored-by: bhavesh-patel <bhavesh.patel@madetech.com>